### PR TITLE
Fix indices in quickMoveStack method

### DIFF
--- a/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainerBase.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainerBase.java
@@ -523,21 +523,21 @@ public abstract class BlockIronFurnaceContainerBase extends AbstractContainerMen
                         if (!this.moveItemStackTo(itemstack1, 5, 6, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (index >= 19 && index < 45) {
-                        if (!this.moveItemStackTo(itemstack1, 45, 54, false)) {
+                    } else if (index >= 19 && index < 46) {
+                        if (!this.moveItemStackTo(itemstack1, 46, 55, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (index >= 45 && index < 54 && !this.moveItemStackTo(itemstack1, 19, 45, false)) {
+                    } else if (index >= 46 && index < 55 && !this.moveItemStackTo(itemstack1, 19, 46, false)) {
                         return ItemStack.EMPTY;
                     }
-                } else if (!this.moveItemStackTo(itemstack1, 19, 54, false)) {
+                } else if (!this.moveItemStackTo(itemstack1, 19, 55, false)) {
                     return ItemStack.EMPTY;
                 }
             }
 
             if (te.isFactory()) {
                 if (index >= 12 && index <= 18) {
-                    if (!this.moveItemStackTo(itemstack1, 19, 54, true)) {
+                    if (!this.moveItemStackTo(itemstack1, 19, 55, true)) {
                         return ItemStack.EMPTY;
                     }
 
@@ -575,14 +575,14 @@ public abstract class BlockIronFurnaceContainerBase extends AbstractContainerMen
                         if (!this.moveItemStackTo(itemstack1, 5, 6, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (index >= 19 && index < 45) {
-                        if (!this.moveItemStackTo(itemstack1, 45, 54, false)) {
+                    } else if (index >= 19 && index < 46) {
+                        if (!this.moveItemStackTo(itemstack1, 46, 55, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (index >= 45 && index < 54 && !this.moveItemStackTo(itemstack1, 19, 45, false)) {
+                    } else if (index >= 46 && index < 55 && !this.moveItemStackTo(itemstack1, 19, 46, false)) {
                         return ItemStack.EMPTY;
                     }
-                } else if (!this.moveItemStackTo(itemstack1, 19, 54, false)) {
+                } else if (!this.moveItemStackTo(itemstack1, 19, 55, false)) {
                     return ItemStack.EMPTY;
                 }
             }
@@ -590,7 +590,7 @@ public abstract class BlockIronFurnaceContainerBase extends AbstractContainerMen
             {
 
                 if (index == 2) {
-                    if (!this.moveItemStackTo(itemstack1, 19, 54, true)) {
+                    if (!this.moveItemStackTo(itemstack1, 19, 55, true)) {
                         return ItemStack.EMPTY;
                     }
 
@@ -616,14 +616,14 @@ public abstract class BlockIronFurnaceContainerBase extends AbstractContainerMen
                         if (!this.moveItemStackTo(itemstack1, 5, 6, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (index >= 19 && index < 45) {
-                        if (!this.moveItemStackTo(itemstack1, 45, 54, false)) {
+                    } else if (index >= 19 && index < 46) {
+                        if (!this.moveItemStackTo(itemstack1, 46, 55, false)) {
                             return ItemStack.EMPTY;
                         }
-                    } else if (index >= 45 && index < 54 && !this.moveItemStackTo(itemstack1, 19, 45, false)) {
+                    } else if (index >= 46 && index < 55 && !this.moveItemStackTo(itemstack1, 19, 46, false)) {
                         return ItemStack.EMPTY;
                     }
-                } else if (!this.moveItemStackTo(itemstack1, 19, 54, false)) {
+                } else if (!this.moveItemStackTo(itemstack1, 19, 55, false)) {
                     return ItemStack.EMPTY;
                 }
             }

--- a/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainerBase.java
+++ b/src/main/java/ironfurnaces/container/furnaces/BlockIronFurnaceContainerBase.java
@@ -536,7 +536,7 @@ public abstract class BlockIronFurnaceContainerBase extends AbstractContainerMen
             }
 
             if (te.isFactory()) {
-                if (index >= 12 && index <= 18) {
+                if (index >= 13 && index <= 18) {
                     if (!this.moveItemStackTo(itemstack1, 19, 55, true)) {
                         return ItemStack.EMPTY;
                     }


### PR DESCRIPTION
Some of the indices used to determine the behaviour of the quickMoveStack method are wrong, which results in incorrect quickMoveStack actions. For example, quick moving a stack from the last hotbar action does not work.

This MR just serves to fix these indices, although if you don't mind I could also improve, in a separate branch, the implementation to potentially avoid these kind of errors in the future (it would also serve me to learn more about modding MC :smile:  )